### PR TITLE
chore: MikanseiLaboratory org URLs and branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# 未完成成果物研究所 Landing Page
+# Mikansei Laboratory（未完成成果物研究所）Landing Page
 
-未完成成果物研究所のランディングページです。
+Mikansei Laboratory（未完成成果物研究所）のランディングページです。
 
-公開 URL: [https://incomplete-outputs-lab.github.io/](https://incomplete-outputs-lab.github.io/)
+GitHub 組織: [https://github.com/MikanseiLaboratory](https://github.com/MikanseiLaboratory)
+
+公開 URL: [https://mikanseilaboratory.github.io/](https://mikanseilaboratory.github.io/)
 
 ## 技術スタック
 

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>未完成成果物研究所 | Incomplete Outputs Lab</title>
+    <title>未完成成果物研究所 | Mikansei Laboratory</title>
     <meta
       name="description"
       content="配信プロダクション向けツールおよびハードウェア機材の研究開発を行う技術者コミュニティ。vMix、ATEM、NDI など現場最適化のためのツール群を開発しています。"
     />
-    <meta property="og:title" content="未完成成果物研究所 | Incomplete Outputs Lab" />
+    <meta property="og:title" content="未完成成果物研究所 | Mikansei Laboratory" />
     <meta
       property="og:description"
       content="配信プロダクション向けツールおよびハードウェア機材の研究開発を行う技術者コミュニティ。"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "incomplete-outputs-lab-site",
+  "name": "mikanseilaboratory-site",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "incomplete-outputs-lab-site",
+      "name": "mikanseilaboratory-site",
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.4",
         "typescript": "~5.7.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "incomplete-outputs-lab-site",
+  "name": "mikanseilaboratory-site",
   "private": true,
   "type": "module",
   "scripts": {

--- a/products.html
+++ b/products.html
@@ -47,7 +47,7 @@
               >詳しく見る</a
             >
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/iryx-manuals"
+              href="https://github.com/MikanseiLaboratory/iryx-manuals"
               class="inline-flex items-center justify-center text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"

--- a/products/iryx.html
+++ b/products/iryx.html
@@ -63,7 +63,7 @@
           <h2 id="iryx-links" class="text-lg font-semibold text-white">ドキュメント・リポジトリ</h2>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/iryx-manuals"
+              href="https://github.com/MikanseiLaboratory/iryx-manuals"
               class="inline-flex text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"

--- a/projects.html
+++ b/projects.html
@@ -47,18 +47,18 @@
               >詳しく見る</a
             >
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases/latest"
+              href="https://github.com/MikanseiLaboratory/vmix-utility/releases/latest"
               class="inline-flex items-center justify-center text-sm font-medium text-zinc-300 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
               >ダウンロード（Releases）</a
             >
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/vmix-utility"
+              href="https://github.com/MikanseiLaboratory/vmix-utility"
               class="inline-flex items-center justify-center text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/vmix-utility</a
+              >GitHub: MikanseiLaboratory/vmix-utility</a
             >
           </p>
         </li>
@@ -75,18 +75,18 @@
               >詳しく見る</a
             >
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/bi-kanpe/releases/latest"
+              href="https://github.com/MikanseiLaboratory/bi-kanpe/releases/latest"
               class="inline-flex items-center justify-center text-sm font-medium text-zinc-300 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
               >ダウンロード（Releases）</a
             >
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/bi-kanpe"
+              href="https://github.com/MikanseiLaboratory/bi-kanpe"
               class="inline-flex items-center justify-center text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/bi-kanpe</a
+              >GitHub: MikanseiLaboratory/bi-kanpe</a
             >
           </p>
         </li>
@@ -103,11 +103,11 @@
               >詳しく見る</a
             >
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/obs-sync"
+              href="https://github.com/MikanseiLaboratory/obs-sync"
               class="inline-flex items-center justify-center text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/obs-sync</a
+              >GitHub: MikanseiLaboratory/obs-sync</a
             >
           </p>
         </li>

--- a/projects/bi-kanpe.html
+++ b/projects/bi-kanpe.html
@@ -66,7 +66,7 @@
           </p>
           <p class="mt-3">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/bi-kanpe/releases/latest"
+              href="https://github.com/MikanseiLaboratory/bi-kanpe/releases/latest"
               class="inline-flex text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
@@ -74,7 +74,7 @@
             >
             <span class="mx-2 text-zinc-600" aria-hidden="true">·</span>
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/bi-kanpe/releases"
+              href="https://github.com/MikanseiLaboratory/bi-kanpe/releases"
               class="inline-flex text-sm font-medium text-zinc-500 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
@@ -87,11 +87,11 @@
           <h2 id="bk-links" class="text-lg font-semibold text-white">ソースコード</h2>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/bi-kanpe"
+              href="https://github.com/MikanseiLaboratory/bi-kanpe"
               class="inline-flex text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/bi-kanpe</a
+              >GitHub: MikanseiLaboratory/bi-kanpe</a
             >
           </p>
         </section>

--- a/projects/obs-sync.html
+++ b/projects/obs-sync.html
@@ -63,11 +63,11 @@
           <h2 id="os-links" class="text-lg font-semibold text-white">ソースコード</h2>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/obs-sync"
+              href="https://github.com/MikanseiLaboratory/obs-sync"
               class="inline-flex text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/obs-sync</a
+              >GitHub: MikanseiLaboratory/obs-sync</a
             >
           </p>
         </section>

--- a/projects/vmix-utility.html
+++ b/projects/vmix-utility.html
@@ -66,7 +66,7 @@
           </p>
           <p class="mt-3">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases/latest"
+              href="https://github.com/MikanseiLaboratory/vmix-utility/releases/latest"
               class="inline-flex text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
@@ -74,7 +74,7 @@
             >
             <span class="mx-2 text-zinc-600" aria-hidden="true">·</span>
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases"
+              href="https://github.com/MikanseiLaboratory/vmix-utility/releases"
               class="inline-flex text-sm font-medium text-zinc-500 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
@@ -87,11 +87,11 @@
           <h2 id="vu-links" class="text-lg font-semibold text-white">ソースコード</h2>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/vmix-utility"
+              href="https://github.com/MikanseiLaboratory/vmix-utility"
               class="inline-flex text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/vmix-utility</a
+              >GitHub: MikanseiLaboratory/vmix-utility</a
             >
           </p>
         </section>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/</loc>
+    <loc>https://mikanseilaboratory.github.io/</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/products.html</loc>
+    <loc>https://mikanseilaboratory.github.io/products.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/projects.html</loc>
+    <loc>https://mikanseilaboratory.github.io/projects.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/products/iryx.html</loc>
+    <loc>https://mikanseilaboratory.github.io/products/iryx.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/products/atem-micro-control-panel.html</loc>
+    <loc>https://mikanseilaboratory.github.io/products/atem-micro-control-panel.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/projects/vmix-utility.html</loc>
+    <loc>https://mikanseilaboratory.github.io/projects/vmix-utility.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/projects/bi-kanpe.html</loc>
+    <loc>https://mikanseilaboratory.github.io/projects/bi-kanpe.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/projects/obs-sync.html</loc>
+    <loc>https://mikanseilaboratory.github.io/projects/obs-sync.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/research.html</loc>
+    <loc>https://mikanseilaboratory.github.io/research.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/members.html</loc>
+    <loc>https://mikanseilaboratory.github.io/members.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/partners.html</loc>
+    <loc>https://mikanseilaboratory.github.io/partners.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/technology.html</loc>
+    <loc>https://mikanseilaboratory.github.io/technology.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://incomplete-outputs-lab.github.io/contact.html</loc>
+    <loc>https://mikanseilaboratory.github.io/contact.html</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/research.html
+++ b/research.html
@@ -42,11 +42,11 @@
           </p>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/rust-ndi-viewer"
+              href="https://github.com/MikanseiLaboratory/rust-ndi-viewer"
               class="text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/rust-ndi-viewer</a
+              >GitHub: MikanseiLaboratory/rust-ndi-viewer</a
             >
           </p>
         </li>
@@ -57,11 +57,11 @@
           </p>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/stream-monitor"
+              href="https://github.com/MikanseiLaboratory/stream-monitor"
               class="text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/stream-monitor</a
+              >GitHub: MikanseiLaboratory/stream-monitor</a
             >
           </p>
         </li>
@@ -73,11 +73,11 @@
           </p>
           <p class="mt-4">
             <a
-              href="https://github.com/Incomplete-Outputs-Lab/ATEM-UI"
+              href="https://github.com/MikanseiLaboratory/ATEM-UI"
               class="text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub: Incomplete-Outputs-Lab/ATEM-UI</a
+              >GitHub: MikanseiLaboratory/ATEM-UI</a
             >
           </p>
         </li>

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ class SiteHeader extends HTMLElement {
         <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 md:py-4">
           <a href="/index.html" class="group flex flex-col focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-cyan-400 rounded-md">
             <span class="text-sm font-semibold tracking-tight text-white group-hover:text-cyan-200 transition-colors">未完成成果物研究所</span>
-            <span class="text-[10px] uppercase tracking-[0.2em] text-zinc-500">Incomplete Outputs Lab</span>
+            <span class="text-[10px] uppercase tracking-[0.2em] text-zinc-500">Mikansei Laboratory</span>
           </a>
           <button
             type="button"
@@ -112,7 +112,7 @@ class SiteFooter extends HTMLElement {
             <p class="text-sm font-semibold text-white">未完成成果物研究所</p>
             <p class="mt-1 text-xs text-zinc-500">配信プロダクション向けツール・ハードウェアの研究開発コミュニティ</p>
           </div>
-          <p class="text-xs text-zinc-500">© ${new Date().getFullYear()} Incomplete Outputs Lab</p>
+          <p class="text-xs text-zinc-500">© ${new Date().getFullYear()} Mikansei Laboratory</p>
         </div>
       </footer>
     `;


### PR DESCRIPTION
Updates site copy and links to match the [MikanseiLaboratory](https://github.com/MikanseiLaboratory) GitHub organization.

- All \github.com/...\ project links use \MikanseiLaboratory\ as the owner.
- Sitemap and README use \https://mikanseilaboratory.github.io/\ for Pages.
- npm package name set to \mikanseilaboratory-site\.
- English lab name in header/footer and \index.html\ metadata remains **Mikansei Laboratory** for display.