### PR TITLE
Members: mizuyoukan 追加、GitHub アイコン、Misei 削除

### DIFF
--- a/members.html
+++ b/members.html
@@ -38,10 +38,20 @@
           <p class="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm">
             <a
               href="https://github.com/FlowingSPDG"
-              class="font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
+              class="inline-flex items-center gap-1.5 font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub</a
+              ><svg
+                class="h-4 w-4 shrink-0"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+                />
+              </svg>
+              GitHub</a
             >
             <a
               href="https://x.com/FlowingSPDG"
@@ -56,26 +66,29 @@
           </p>
         </li>
         <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8 md:p-10">
-          <h2 class="text-xl font-semibold text-white">Misei.</h2>
-          <p class="mt-1 text-sm font-medium text-cyan-400/90">Founder / Engineer</p>
+          <h2 class="text-xl font-semibold text-white">mizuyoukan</h2>
+          <p class="mt-1 text-sm font-medium text-cyan-400/90">Engineer</p>
           <p class="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm">
             <a
-              href="https://github.com/misei-nul"
-              class="font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
+              href="https://github.com/mizuyoukanao"
+              class="inline-flex items-center gap-1.5 font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
               target="_blank"
               rel="noopener noreferrer"
-              >GitHub</a
-            >
-            <a
-              href="https://x.com/miseinul"
-              class="font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
-              target="_blank"
-              rel="noopener noreferrer"
-              >X</a
+              ><svg
+                class="h-4 w-4 shrink-0"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+                />
+              </svg>
+              GitHub</a
             >
           </p>
           <p class="mt-4 leading-relaxed text-zinc-400">
-            プログラマー。誰よりも未完成のプロジェクトが多い。ハードウェアプロダクトの研究・仕様の策定などを担当。
+            ハードウェア担当。回路の設計やパーツ選定、基板や筐体の制作などを担当。
           </p>
         </li>
       </ul>


### PR DESCRIPTION
## 変更内容

- **mizuyoukan** を [github.com/mizuyoukanao](https://github.com/mizuyoukanao) リンク付きで追加
- 各メンバーの GitHub リンクに Octocat SVG アイコンを表示
- **Misei.** エントリを削除

## 確認

- [ ] メンバーページの表示・リンクが意図どおりか