### PR TITLE
Add GitHub and Discord links to footer

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
     <title>お問い合わせ | 未完成成果物研究所</title>
     <meta
       name="description"
-      content="未完成成果物研究所へのお問い合わせ。Discord またはメールでご連絡いただけます。"
+      content="未完成成果物研究所へのお問い合わせ。GitHub・Discord（コミュニティ）またはメールでご連絡いただけます。"
     />
     <meta property="og:title" content="お問い合わせ | 未完成成果物研究所" />
     <meta property="og:type" content="website" />
@@ -41,19 +41,6 @@
           <div class="mt-4">
             <social-links></social-links>
           </div>
-        </li>
-        <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8">
-          <h2 class="text-sm font-semibold uppercase tracking-widest text-zinc-500">Discord</h2>
-          <p class="mt-3 text-lg font-medium text-white">flowingspdg</p>
-          <p class="mt-4">
-            <a
-              href="https://discord.com/users/190716720250355712"
-              class="text-sm font-medium text-cyan-400 hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Discord プロフィールを開く</a
-            >
-          </p>
         </li>
         <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8">
           <h2 class="text-sm font-semibold uppercase tracking-widest text-zinc-500">メール</h2>

--- a/contact.html
+++ b/contact.html
@@ -42,7 +42,7 @@
             サイトのソースコードやコミュニティサーバーはこちらからご覧いただけます。
           </p>
           <div class="mt-6">
-            <social-links aria-label="公式の GitHub と Discord"></social-links>
+            <social-links></social-links>
           </div>
         </li>
         <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8">

--- a/contact.html
+++ b/contact.html
@@ -38,10 +38,7 @@
       <ul class="mt-14 max-w-xl space-y-6">
         <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8">
           <h2 class="text-sm font-semibold uppercase tracking-widest text-zinc-500">GitHub・Discord</h2>
-          <p class="mt-3 text-sm leading-relaxed text-zinc-400">
-            サイトのソースコードやコミュニティサーバーはこちらからご覧いただけます。
-          </p>
-          <div class="mt-6">
+          <div class="mt-4">
             <social-links></social-links>
           </div>
         </li>

--- a/contact.html
+++ b/contact.html
@@ -37,6 +37,15 @@
 
       <ul class="mt-14 max-w-xl space-y-6">
         <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8">
+          <h2 class="text-sm font-semibold uppercase tracking-widest text-zinc-500">GitHub・Discord</h2>
+          <p class="mt-3 text-sm leading-relaxed text-zinc-400">
+            サイトのソースコードやコミュニティサーバーはこちらからご覧いただけます。
+          </p>
+          <div class="mt-6">
+            <social-links aria-label="公式の GitHub と Discord"></social-links>
+          </div>
+        </li>
+        <li class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8">
           <h2 class="text-sm font-semibold uppercase tracking-widest text-zinc-500">Discord</h2>
           <p class="mt-3 text-lg font-medium text-white">flowingspdg</p>
           <p class="mt-4">

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,7 @@ class SiteFooter extends HTMLElement {
             <p class="mt-1 text-xs text-zinc-500">配信プロダクション向けツール・ハードウェアの研究開発コミュニティ</p>
             <nav class="mt-4 flex flex-wrap gap-x-6 gap-y-2" aria-label="外部リンク">
               <a
-                href="https://github.com/Incomplete-Outputs-Lab/Incomplete-Outputs-Lab.github.io"
+                href="https://github.com/MikanseiLaboratory/MikanseiLaboratory.github.io"
                 class="text-sm text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,20 @@ class SiteFooter extends HTMLElement {
           <div>
             <p class="text-sm font-semibold text-white">未完成成果物研究所</p>
             <p class="mt-1 text-xs text-zinc-500">配信プロダクション向けツール・ハードウェアの研究開発コミュニティ</p>
+            <nav class="mt-4 flex flex-wrap gap-x-6 gap-y-2" aria-label="外部リンク">
+              <a
+                href="https://github.com/Incomplete-Outputs-Lab/Incomplete-Outputs-Lab.github.io"
+                class="text-sm text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
+                target="_blank"
+                rel="noopener noreferrer"
+              >GitHub</a>
+              <a
+                href="https://discord.gg/YUbmg9Hq37"
+                class="text-sm text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
+                target="_blank"
+                rel="noopener noreferrer"
+              >Discord</a>
+            </nav>
           </div>
           <p class="text-xs text-zinc-500">© ${new Date().getFullYear()} Mikansei Laboratory</p>
         </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,17 @@ const NAV: { id: PageId; href: string; label: string }[] = [
   { id: "contact", href: "/contact.html", label: "お問い合わせ" },
 ];
 
+const SITE_GITHUB_HREF = "https://github.com/MikanseiLaboratory/MikanseiLaboratory.github.io";
+const DISCORD_INVITE_HREF = "https://discord.gg/YUbmg9Hq37";
+
+const ICON_GITHUB = `<svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+</svg>`;
+
+const ICON_DISCORD = `<svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+</svg>`;
+
 function navLinkClass(current: PageId, id: PageId): string {
   const base =
     "rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400";
@@ -33,6 +44,29 @@ function buildNavItems(current: PageId): string {
     (item) =>
       `<a href="${item.href}" class="${navLinkClass(current, item.id)}">${item.label}</a>`,
   ).join("");
+}
+
+class SocialLinks extends HTMLElement {
+  connectedCallback(): void {
+    const variant = this.getAttribute("data-variant") ?? "page";
+    const ariaLabel = this.getAttribute("aria-label") ?? "GitHub と Discord";
+    const linkClass =
+      variant === "footer"
+        ? "inline-flex items-center gap-2 rounded text-sm font-medium text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400"
+        : "inline-flex items-center gap-2 rounded text-sm font-medium text-cyan-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400";
+    this.innerHTML = `
+      <nav class="flex flex-wrap gap-x-6 gap-y-2" aria-label="${ariaLabel}">
+        <a href="${SITE_GITHUB_HREF}" class="${linkClass}" target="_blank" rel="noopener noreferrer">
+          ${ICON_GITHUB}
+          <span>GitHub</span>
+        </a>
+        <a href="${DISCORD_INVITE_HREF}" class="${linkClass}" target="_blank" rel="noopener noreferrer">
+          ${ICON_DISCORD}
+          <span>Discord</span>
+        </a>
+      </nav>
+    `;
+  }
 }
 
 class SiteHeader extends HTMLElement {
@@ -121,20 +155,9 @@ class SiteFooter extends HTMLElement {
           <div>
             <p class="text-sm font-semibold text-white">未完成成果物研究所</p>
             <p class="mt-1 text-xs text-zinc-500">配信プロダクション向けツール・ハードウェアの研究開発コミュニティ</p>
-            <nav class="mt-4 flex flex-wrap gap-x-6 gap-y-2" aria-label="外部リンク">
-              <a
-                href="https://github.com/MikanseiLaboratory/MikanseiLaboratory.github.io"
-                class="text-sm text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
-                target="_blank"
-                rel="noopener noreferrer"
-              >GitHub</a>
-              <a
-                href="https://discord.gg/YUbmg9Hq37"
-                class="text-sm text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
-                target="_blank"
-                rel="noopener noreferrer"
-              >Discord</a>
-            </nav>
+            <div class="mt-4">
+              <social-links data-variant="footer" aria-label="外部リンク"></social-links>
+            </div>
           </div>
           <p class="text-xs text-zinc-500">© ${new Date().getFullYear()} Mikansei Laboratory</p>
         </div>
@@ -143,5 +166,6 @@ class SiteFooter extends HTMLElement {
   }
 }
 
+customElements.define("social-links", SocialLinks);
 customElements.define("site-header", SiteHeader);
 customElements.define("site-footer", SiteFooter);

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,9 @@ function buildNavItems(current: PageId): string {
 class SocialLinks extends HTMLElement {
   connectedCallback(): void {
     const variant = this.getAttribute("data-variant") ?? "page";
-    const ariaLabel = this.getAttribute("aria-label") ?? "GitHub と Discord";
+    const ariaLabel =
+      this.getAttribute("aria-label") ??
+      (variant === "footer" ? "外部リンク" : "公式の GitHub と Discord");
     const linkClass =
       variant === "footer"
         ? "inline-flex items-center gap-2 rounded text-sm font-medium text-zinc-400 transition-colors hover:text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400"
@@ -156,7 +158,7 @@ class SiteFooter extends HTMLElement {
             <p class="text-sm font-semibold text-white">未完成成果物研究所</p>
             <p class="mt-1 text-xs text-zinc-500">配信プロダクション向けツール・ハードウェアの研究開発コミュニティ</p>
             <div class="mt-4">
-              <social-links data-variant="footer" aria-label="外部リンク"></social-links>
+              <social-links data-variant="footer"></social-links>
             </div>
           </div>
           <p class="text-xs text-zinc-500">© ${new Date().getFullYear()} Mikansei Laboratory</p>


### PR DESCRIPTION
Adds external links in the site footer:

- GitHub: canonical repository for this site
- Discord: community invite (`YUbmg9Hq37`)

Links use `target="_blank"` with `rel="noopener noreferrer"` and match existing zinc/cyan hover styling used elsewhere on the site.

Made with [Cursor](https://cursor.com)